### PR TITLE
Emoji support for webhooks

### DIFF
--- a/include/slacking/slacking.hpp
+++ b/include/slacking/slacking.hpp
@@ -674,7 +674,7 @@ inline Json CategoryWebHook::postMessage(const std::string& text,
     auto str_channel = specified_channel.empty() ? channel : specified_channel;
     auto str_emoji = icon_emoji.empty()? "" : icon_emoji;
 
-    Json json_arguments = {{"text", text}, {"channel", str_channel}};
+    Json json_arguments = {{"text", text}, {"channel", str_channel},{ "icon_emoji" , str_emoji} };
 
     // in this case we did not use  Slack web api
     std::string baseUrl = slack_.getBaseUrl();

--- a/include/slacking/slacking.hpp
+++ b/include/slacking/slacking.hpp
@@ -672,6 +672,7 @@ Json CategoryChat::postMessage(const std::string& text, const std::string& speci
 inline Json CategoryWebHook::postMessage(const std::string& text,
                                          const std::string& specified_channel) {
     auto str_channel = specified_channel.empty() ? channel : specified_channel;
+    auto str_emoji = icon_emoji.empty()? "" : icon_emoji;
 
     Json json_arguments = {{"text", text}, {"channel", str_channel}};
 


### PR DESCRIPTION
A one line change to retrieve emoji preference set via hook.channeò_username_emoji