### PR TITLE
fix compilation when nlohmann::json implicit conversions are turned off

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.0)
+project(slacking)
 
 include_directories("include/slacking")
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.0)
 
 project(examples)
 
@@ -12,6 +12,8 @@ if(CURL_STATIC_LINKING)
     message("-DCURL_STATICLIB [added]")
     add_definitions(-DCURL_STATICLIB)
 endif()
+
+add_definitions(-DJSON_USE_IMPLICIT_CONVERSIONS=0)
 
 find_package(CURL REQUIRED)
 

--- a/include/slacking/slacking.hpp
+++ b/include/slacking/slacking.hpp
@@ -638,7 +638,7 @@ auto CategoryConversations::list_magic(bool exclude_archived) -> std::vector<Cha
     auto channels = std::vector<Channel>{};
     channels.reserve(json_channels.size());
     for (auto channel : json_channels) {
-        channels.emplace_back(channel["id"], channel["name"], channel["num_members"]);
+        channels.emplace_back(channel["id"].get<std::string>(), channel["name"].get<std::string>(), channel["num_members"].get<int>());
     }
     return channels;
 }
@@ -706,9 +706,9 @@ auto CategoryUsers::list_magic(bool presence) -> std::vector<User> {
         auto email = member["profile"].count("email") ? member["profile"]["email"].dump() : ""; // dump here because email can be null
         bool is_bot = true;
         if (member["is_bot"].is_boolean()) { 
-            is_bot = member["is_bot"]; 
+            is_bot = member["is_bot"].get<bool>(); 
         }
-        users.emplace_back(member["id"], member["name"], email, member["profile"]["real_name"], presence_json, is_bot);
+        users.emplace_back(member["id"].get<std::string>(), member["name"].get<std::string>(), email, member["profile"]["real_name"].get<std::string>(), presence_json.get<std::string>(), is_bot);
     }
     return users;
 }


### PR DESCRIPTION
Per https://github.com/nlohmann/json/blob/d3e347bd2d5bdb52f3d376440a760bbef866f2b9/docs/mkdocs/docs/api/macros/json_use_implicit_conversions.md implicit conversions are going away in nlohmann::json. And we have them turned off in our code base. This PR fixes compilation when that preprocessor symbol is on (and doesn't break things when it is off).

It also works around some cmake warnings (but that could be rolled back).